### PR TITLE
Fix blurry SVG

### DIFF
--- a/js/editor/index.js
+++ b/js/editor/index.js
@@ -130,9 +130,9 @@ export function notFound() {
   return h("div", "Unwritten tale…");
 }
 
-function poster(url) {
-  return h("img.poster", {
-    attrs: { src: url },
+function poster(url, type) {
+  return h("object.poster", {
+    attrs: { data: url, type },
   });
 }
 
@@ -239,7 +239,7 @@ let navigator = (tale, transformMatrix, cameraPosition, activeSlide) => {
       },
     },
     [
-      poster(`/editor/${tale.slug}/${tale["file-path"]}`),
+      poster(`/editor/${tale.slug}/${tale["file-path"]}`, tale.fileType),
       layer(
         {
           on: {

--- a/js/editor/upload.js
+++ b/js/editor/upload.js
@@ -8,6 +8,7 @@ export let uploader = tale => {
     h("input", {
       attrs: {
         type: "file",
+        accept: "image/*",
       },
       on: {
         change: ev => {

--- a/js/presenter/index.js
+++ b/js/presenter/index.js
@@ -40,9 +40,10 @@ export let presenter = tale => {
           },
         },
       },
-      h("img", {
+      h("object", {
         attrs: {
-          src: `/editor/${tale.slug}/${tale["file-path"]}`,
+          data: `/editor/${tale.slug}/${tale["file-path"]}`,
+          type: tale.fileType,
         },
       }),
     ),

--- a/pkg/project/fs.go
+++ b/pkg/project/fs.go
@@ -131,6 +131,7 @@ func (fr *FilesystemRepository) SaveImage(slug, contentType string, data []byte)
 		return Project{}, err
 	}
 	project.FilePath = filename
+	project.FileType = contentType
 	project, err = fr.SaveProject(slug, project)
 	if err != nil {
 		return Project{}, err

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -24,6 +24,7 @@ type Project struct {
 	Slug       string     `json:"slug"`
 	Name       string     `json:"name"`
 	FilePath   string     `json:"file-path" edn:"file-path"`
+	FileType   string     `json:"fileType" edn:"fileType"`
 	Dimensions Dimensions `json:"dimensions"`
 	Slides     []Slide    `json:"slides"`
 }

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -230,7 +230,8 @@ func TestAPI_updateProjectImage(t *testing.T) {
 		header.Add("Content-Type", "image/bmp")
 		resp := tc.RequestWithHeaders("PUT", "/api/tales/foo/image", data, header)
 
-		AssertProjectResponse(t, resp, project.Project{Slug: "foo", Name: "Bar", FilePath: "foo.bmp"}, 202)
+		AssertProjectResponse(t, resp, project.Project{Slug: "foo", Name: "Bar", FilePath: "foo.bmp",
+			FileType: "image/bmp"}, 202)
 	})
 	t.Run("invalid content type", func(t *testing.T) {
 		tc := NewTestClient(t)


### PR DESCRIPTION
This attempts to fix an issue where very large SVG images are rendered blurry in Firefox. The problem occures whenever an image is rendered extremely large (> 10k px width or height), either because the image file itself is large or it is zoomed in.

The issue seems to disappear when the image is embedded in an `object` element instead of an `img` so this workaround is employed here.