### PR TITLE
Fix broken drag and drop

### DIFF
--- a/js/editor/preview.js
+++ b/js/editor/preview.js
@@ -36,12 +36,12 @@ function previewItem([tw, th], tale, slide, index, active) {
         dragging: previewMove.isDragging(),
       },
       on: {
-        dragstart: [previewMove.dragStart, index],
-        dragenter: [previewMove.dragEnter, index],
-        dragover: [previewMove.dragOver, index, th],
-        dragleave: [previewMove.dragLeave, index],
-        drop: [previewMove.drop, index, th],
-        dragend: [previewMove.dragEnd],
+        dragstart: ev => previewMove.dragStart(index, ev),
+        dragenter: ev => previewMove.dragEnter(index, ev),
+        dragover: ev => previewMove.dragOver(index, th, ev),
+        dragleave: ev => previewMove.dragLeave(index, ev),
+        drop: ev => previewMove.drop(index, th, ev),
+        dragend: ev => previewMove.dragEnd(ev),
       },
     },
     [


### PR DESCRIPTION
* snabbdom v2.0.0 removed support for loaded/carrying event listeners (i.e. passing listener and parameters as array), so we replace those with 'classic' arrow functions. See [snabbdom's change log](https://github.com/snabbdom/snabbdom/blob/master/CHANGELOG.md#200-2020-09-10). 
* Drag and drop is broken because of this :frowning_face: 