### PR TITLE
Fix presenter issues

### DIFF
--- a/js/presenter/index.js
+++ b/js/presenter/index.js
@@ -41,7 +41,7 @@ export let presenter = tale => {
           },
         },
       },
-      h("object", {
+      h("object.poster", {
         attrs: {
           data: `/editor/${tale.slug}/${tale["file-path"]}`,
           type: tale.fileType,

--- a/js/project.test.js
+++ b/js/project.test.js
@@ -1,4 +1,4 @@
-import { findTale } from "./project";
+import { findTale, resetView } from "./project";
 
 describe("findTale", () => {
   it("returns tale with matching slug", () => {
@@ -9,5 +9,27 @@ describe("findTale", () => {
   it("returns undefined when no matching tale is found", () => {
     let tales = [{ slug: "foo" }];
     expect(findTale([tales, "bar"])).toBeUndefined();
+  });
+});
+
+describe("resetView", () => {
+  it("resets the camera to show the complete active poster", () => {
+    let effects = resetView({
+      tales: [
+        { slug: "foo", dimensions: { x: 0, y: 0, width: 200, height: 200 } },
+      ],
+      activeTale: "foo",
+    });
+    expect(effects.trigger).toEqual([
+      "camera/fit-rect",
+      { x: 0, y: 0, width: 200, height: 200 },
+    ]);
+  });
+  it("gracefully handles non-existing tales", () => {
+    let effects = resetView({
+      tales: [],
+      activeTale: "foo",
+    });
+    expect(effects).toBeFalsy();
   });
 });

--- a/public/css/tales.css
+++ b/public/css/tales.css
@@ -657,8 +657,10 @@ input[type="checkbox"]:focus {
   display: none;
 }
 
-#editor .poster {
+#editor .poster,
+#presenter .poster {
   user-select: none;
+  pointer-events: none;
 }
 
 #editor .layer.dim {


### PR DESCRIPTION
* Prevent SVGs from stealing focus:
  * If the poster SVG contains selectable elements (like text) it's possible to permanently lose focus when clicking those elements. In thise case it will no longer be possible to use keyboard shortcuts, so e.g. in presenter mode the user is prevented from navigating the Tale or exiting presenter mode via ESC key. 
  * To avoid this the poster SVG will ignore all pointer events and disable text selection.
* Reset view when opening the presenter
  * When starting the presentation, show the whole poster instead of the zoomed-in segment that was visible in the editor.