### PR TITLE
Change slide preview aspect ratio to 16/9

### DIFF
--- a/js/editor/preview.js
+++ b/js/editor/preview.js
@@ -97,7 +97,7 @@ export const preview = withInputSignals(
   () => [connect("editor/active-slide"), connect("camera/rect")],
   ([activeSlide, cameraRect], tale) => {
     let tw = 200,
-      th = 150;
+      th = 112; // aspect ratio 16:9
 
     let onInsert = index => {
       let croppedRect = intersectRects(cameraRect, {


### PR DESCRIPTION
* The old aspect ratio was 4/3 (e.g. 1920x1440 px)
  which is really uncommon for screens/projectors.
* Today most screens have an aspect ratio of
  16/9 (e.g. 1920x1080 px) so this seems like the
  better default.
* In the future this should probably be a user
  setting.