### PR TITLE
Window resize bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Some examples of already existing Tales:
 
 # Contributing
 
-- Install `git`
-- Install `make`
-- Install `go`
-- Install `nodejs`
+- Install `git`, `make`, `go` and `nodejs`
 - Build with `make all`
+- Start with `make run`
+- Visit http://127.0.0.1:3000 in your browser
+- Start hacking! 🙂
 
 
 # Licencse

--- a/js/editor/index.js
+++ b/js/editor/index.js
@@ -146,19 +146,13 @@ const layer = withInputSignals(
 );
 
 let navigator = (tale, transformMatrix, cameraPosition, activeSlide) => {
-  let elm,
-    projectFn = vec =>
+  let projectFn = vec =>
       vec3.transformMat4(
         vec3.create(),
         vec,
         mat4.invert(mat4.create(), transformMatrix),
       ),
     scale = mat4.getScaling(vec3.create(), transformMatrix)[0];
-
-  let onWindowResize = () => {
-    let { left, top, width, height } = elm.getBoundingClientRect();
-    trigger("viewport/set-rect", [left, top, width, height]);
-  };
 
   let startCreate = ev => {
     if (ev.ctrlKey || ev.metaKey) {
@@ -232,17 +226,6 @@ let navigator = (tale, transformMatrix, cameraPosition, activeSlide) => {
       on: {
         wheel: ev => onWheel(ev, projectFn),
         mousedown: ev => onMouseDown(ev, cameraPosition, projectFn),
-      },
-      hook: {
-        insert: vnode => {
-          elm = vnode.elm;
-          window.addEventListener("resize", onWindowResize);
-          onWindowResize();
-        },
-        remove: () => {
-          elm = null;
-          window.removeEventListener("resize", onWindowResize);
-        },
       },
     },
     [

--- a/js/presenter/index.js
+++ b/js/presenter/index.js
@@ -1,4 +1,3 @@
-import { trigger } from "flyps";
 import { h } from "flyps-dom-snabbdom";
 
 import { viewport } from "../viewport";
@@ -17,30 +16,11 @@ export let presenter = tale => {
     return notFound();
   }
 
-  let elm;
-
-  let onWindowResize = () => {
-    let { left, top, width, height } = elm.getBoundingClientRect();
-    trigger("viewport/set-rect", [left, top, width, height]);
-  };
-
   return h("div#presenter", [
     viewport(
       tale.dimensions.width,
       tale.dimensions.height,
-      {
-        hook: {
-          insert: vnode => {
-            elm = vnode.elm;
-            window.addEventListener("resize", onWindowResize);
-            onWindowResize();
-          },
-          remove: () => {
-            elm = null;
-            window.removeEventListener("resize", onWindowResize);
-          },
-        },
-      },
+      {},
       h("object.poster", {
         attrs: {
           data: `/editor/${tale.slug}/${tale["file-path"]}`,

--- a/js/viewport.test.js
+++ b/js/viewport.test.js
@@ -4,7 +4,12 @@ import {
   getViewportMatrix,
   setViewportRect,
   viewport,
+  windowResizeListener,
 } from "./viewport";
+import * as flyps from "flyps";
+
+// eslint-disable-next-line no-import-assign
+flyps.trigger = jest.fn();
 
 describe("viewport", () => {
   it("gets rect", () => {
@@ -67,5 +72,42 @@ describe("viewport", () => {
     expect(world.children.length).toBe(2);
     expect(world.children[0].text).toBe("foo");
     expect(world.children[1].text).toBe("bar");
+  });
+});
+
+describe("windowResizeListener", () => {
+  beforeEach(() => {
+    flyps.trigger.mockClear();
+  });
+  const elm = {
+    getBoundingClientRect: () => ({
+      left: 1,
+      top: 2,
+      width: 3,
+      height: 4,
+    }),
+  };
+
+  it("adds the listener and calls it once", () => {
+    jest.spyOn(window, "addEventListener");
+    jest.spyOn(window, "removeEventListener");
+    windowResizeListener.add(elm);
+
+    expect(window.addEventListener).toBeCalledWith("resize", expect.anything());
+    expect(window.removeEventListener).not.toHaveBeenCalled();
+    expect(flyps.trigger).toHaveBeenCalledWith(
+      "viewport/set-rect",
+      [1, 2, 3, 4],
+    );
+  });
+  it("removes the listener", () => {
+    jest.spyOn(window, "removeEventListener");
+    windowResizeListener.add(elm);
+    windowResizeListener.remove();
+
+    expect(window.removeEventListener).toBeCalledWith(
+      "resize",
+      expect.anything(),
+    );
   });
 });

--- a/public/css/tales.css
+++ b/public/css/tales.css
@@ -527,6 +527,7 @@ input[type="checkbox"]:focus {
   height: 100%;
   display: flex;
   align-items: center;
+  justify-content: center;
   background-color: var(--preview-overlay-bg);
   text-align: center;
   font-size: 1.5rem;


### PR DESCRIPTION
Two problems led to the resize event listener not being removed once the viewport DOM element got destroyed.
This caused a crash after resizing the window on pages without a viewport (e.g. the 'home' page of Tales).

Also slightly improve contribution instructions in the README and fix a minor visual alignment bug.