### PR TITLE
Fix export of tales with large posters

### DIFF
--- a/src/js/viewer/index.js
+++ b/src/js/viewer/index.js
@@ -37,11 +37,17 @@ export const init = (tale, imgData) => {
 
   trigger("project/reset-view");
 
-  mount(
-    document.querySelector("#app"),
-    withInputSignals(
-      () => [connect("tale"), connect("slide/active")],
-      ([tale, activeSlide]) => viewer(tale, imgData, activeSlide),
-    ),
-  );
+  fetch(imgData)
+    .then(res => res.blob())
+    .then(blob => {
+      const objectURL = window.URL.createObjectURL(blob);
+
+      mount(
+        document.querySelector("#app"),
+        withInputSignals(
+          () => [connect("tale"), connect("slide/active")],
+          ([tale, activeSlide]) => viewer(tale, objectURL, activeSlide),
+        ),
+      );
+    });
 };

--- a/src/js/viewer/viewer.js
+++ b/src/js/viewer/viewer.js
@@ -5,7 +5,7 @@ import { trigger } from "flyps";
 
 const notFound = () => h("div", "An unwritten tale…");
 
-export const viewer = (tale, imgData, activeSlide) => {
+export const viewer = (tale, posterUrl, activeSlide) => {
   if (!tale) {
     return notFound();
   }
@@ -18,17 +18,17 @@ export const viewer = (tale, imgData, activeSlide) => {
         tale.dimensions.width,
         tale.dimensions.height,
         {},
-        poster(imgData, tale.fileType),
+        poster(posterUrl, tale.fileType),
       ),
       controls(tale, activeSlide),
     ],
   );
 };
 
-const poster = (imgData, fileType) => {
+const poster = (posterUrl, fileType) => {
   return h("object.poster", {
     attrs: {
-      data: imgData,
+      data: posterUrl,
       type: fileType,
     },
   });


### PR DESCRIPTION
* Chromium-based browser do not support embedded media with data URLs >2MB. A better solution is to parse the data URL as a blob and create an ObjectURL that can be used as media source.