### PR TITLE
Modernize go API server

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,0 @@
-issues:
-  exclude-rules:
-    - path: (.+)_test.go
-      linters:
-        - errcheck

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module synyx.de/tales
 go 1.22
 
 require (
-	github.com/gorilla/mux v1.8.1
 	github.com/mozillazg/go-slugify v0.2.0
 	github.com/stretchr/testify v1.9.0
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/mozillazg/go-slugify v0.2.0 h1:SIhqDlnJWZH8OdiTmQgeXR28AOnypmAXPeOTcG7b9lk=
 github.com/mozillazg/go-slugify v0.2.0/go.mod h1:z7dPH74PZf2ZPFkyxx+zjPD8CNzRJNa1CGacv0gg8Ns=
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -16,5 +16,6 @@ func FormattedGitSHA() string {
 	if GitTreeState != "clean" {
 		return fmt.Sprintf("%s-%s", GitSHA, GitTreeState)
 	}
+
 	return GitSHA
 }

--- a/pkg/buildinfo/version_test.go
+++ b/pkg/buildinfo/version_test.go
@@ -1,0 +1,23 @@
+package buildinfo
+
+import "testing"
+
+func TestCleanState(t *testing.T) {
+	Version = "1.0"
+	GitSHA = "2547ce676b1f899d08c61c5367c635c76505b443"
+	GitTreeState = "clean"
+
+	if sha := FormattedGitSHA(); sha != GitSHA {
+		t.Errorf("git sha should be %s, got %s", GitSHA, sha)
+	}
+}
+
+func TestDirtyState(t *testing.T) {
+	Version = "1.0"
+	GitSHA = "2547ce676b1f899d08c61c5367c635c76505b443"
+	GitTreeState = "dirty"
+
+	if sha := FormattedGitSHA(); sha != GitSHA+"-dirty" {
+		t.Errorf("git sha should be %s, got %s", GitSHA, sha)
+	}
+}

--- a/pkg/project/fs.go
+++ b/pkg/project/fs.go
@@ -27,7 +27,7 @@ func (fr *FilesystemRepository) imageFile(slug, filename string) string {
 func (fr *FilesystemRepository) Exists(slug string) (bool, error) {
 	dir, err := os.Stat(fr.ProjectDir)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("project directory %s not accessible: %w", fr.ProjectDir, err)
 	}
 	if !dir.IsDir() {
 		return false, fmt.Errorf("project directory %s is not a directory", fr.ProjectDir)

--- a/pkg/project/fs_test.go
+++ b/pkg/project/fs_test.go
@@ -14,9 +14,13 @@ func TestFilesystemRepository_Exists(t *testing.T) {
 	defer os.RemoveAll(repo.ProjectDir)
 
 	t.Run("checks existence", func(t *testing.T) {
-		assert.False(t, repo.Exists("project-1"))
-		repo.SaveProject("project-1", Project{Name: "Project 1"})
-		assert.True(t, repo.Exists("project-1"))
+		exists, _ := repo.Exists("project-1")
+		assert.False(t, exists)
+
+		_, _ = repo.SaveProject("project-1", Project{Name: "Project 1"})
+
+		exists, _ = repo.Exists("project-1")
+		assert.True(t, exists)
 	})
 }
 

--- a/pkg/project/fs_test.go
+++ b/pkg/project/fs_test.go
@@ -31,11 +31,11 @@ func TestFilesystemRepository_LoadProjects(t *testing.T) {
 		defer os.RemoveAll(repo.ProjectDir)
 
 		project1 := Project{Name: "Project 1"}
-		repo.SaveProject("project-1", project1)
+		_, _ = repo.SaveProject("project-1", project1)
 		project2 := Project{Name: "Project 2"}
-		repo.SaveProject("project-2", project2)
+		_, _ = repo.SaveProject("project-2", project2)
 		project3 := Project{Name: "Project 3"}
-		repo.SaveProject("project-3", project3)
+		_, _ = repo.SaveProject("project-3", project3)
 
 		projects, err := repo.LoadProjects()
 		assert.Nil(t, err)
@@ -46,7 +46,9 @@ func TestFilesystemRepository_LoadProjects(t *testing.T) {
 	})
 	t.Run("non-existing repo directory", func(t *testing.T) {
 		repo := testRepo(t)
-		os.RemoveAll(repo.ProjectDir)
+		if err := os.RemoveAll(repo.ProjectDir); err != nil {
+			t.Fatal("could not delete project dir for testing", err)
+		}
 
 		projects, err := repo.LoadProjects()
 		assert.NotNil(t, err)
@@ -118,7 +120,7 @@ func TestFilesystemRepository_LoadProject(t *testing.T) {
 	})
 	t.Run("load existing project", func(t *testing.T) {
 		project1 := Project{Name: "Project 1"}
-		repo.SaveProject("project-1", project1)
+		_, _ = repo.SaveProject("project-1", project1)
 		project, err := repo.LoadProject("project-1")
 		assert.Nil(t, err)
 		assert.Equal(t, project1, project)
@@ -153,7 +155,7 @@ func TestFilesystemRepository_DeleteProject(t *testing.T) {
 	})
 	t.Run("delete valid project", func(t *testing.T) {
 		project := Project{Name: "Foo"}
-		repo.SaveProject("foo", project)
+		_, _ = repo.SaveProject("foo", project)
 		_, err := repo.LoadProject("foo")
 		assert.Nil(t, err)
 		err = repo.DeleteProject("foo")
@@ -177,13 +179,13 @@ func TestFilesystemRepository_SaveImage(t *testing.T) {
 	})
 	t.Run("save image with invalid content-type", func(t *testing.T) {
 		project := Project{}
-		repo.SaveProject("project", project)
+		_, _ = repo.SaveProject("project", project)
 		_, err := repo.SaveImage("project", "foo/bar", []byte{})
 		assert.EqualError(t, err, "unsupported content-type: foo/bar")
 	})
 	t.Run("save image for valid project", func(t *testing.T) {
 		project := Project{}
-		repo.SaveProject("project", project)
+		_, _ = repo.SaveProject("project", project)
 		savedProject, err := repo.SaveImage("project", "image/jpeg", []byte{'f', 'o', 'o'})
 		assert.NoError(t, err)
 		assert.Equal(t, "project.jpg", savedProject.FilePath)

--- a/pkg/project/fs_test.go
+++ b/pkg/project/fs_test.go
@@ -196,5 +196,6 @@ func TestFilesystemRepository_SaveImage(t *testing.T) {
 func testRepo(t *testing.T) FilesystemRepository {
 	dir, err := os.MkdirTemp("", "tales-test")
 	assert.Nil(t, err)
+
 	return FilesystemRepository{dir}
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -37,7 +37,7 @@ type Project struct {
 
 // A Repository manages projects.
 type Repository interface {
-	Exists(string) bool
+	Exists(string) (bool, error)
 	LoadProjects() ([]Project, error)
 	LoadProject(string) (Project, error)
 	SaveProject(string, Project) (Project, error)

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -10,117 +10,110 @@ import (
 	"synyx.de/tales/pkg/project"
 )
 
-func listProjects(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		projects, err := repository.LoadProjects()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		jsonResponse(w, projects, http.StatusOK)
+func (s *server) listProjects(w http.ResponseWriter, r *http.Request) {
+	projects, err := s.repository.LoadProjects()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+	jsonResponse(w, projects, http.StatusOK)
+
 }
 
-func loadProject(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		slug := r.PathValue("slug")
-		if !repository.Exists(slug) {
-			notFound(w)
-			return
-		}
-		proj, err := repository.LoadProject(slug)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		jsonResponse(w, proj, http.StatusOK)
+func (s *server) loadProject(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if !s.repository.Exists(slug) {
+		notFound(w)
+		return
 	}
+	proj, err := s.repository.LoadProject(slug)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, proj, http.StatusOK)
+
 }
 
-func createProject(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		proj, err := extractProject(r)
-		if err != nil {
-			badRequest(w)
-			return
-		}
-		if proj.Slug == "" {
-			proj.Slug = slugify.Slugify(proj.Name)
-		}
-		if proj.Slug == "" {
-			badRequest(w)
-			return
-		}
-		if repository.Exists(proj.Slug) {
-			conflict(w)
-			return
-		}
-		proj, err = repository.SaveProject(proj.Slug, proj)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		jsonResponse(w, proj, http.StatusCreated)
+func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
+	proj, err := extractProject(r)
+	if err != nil {
+		badRequest(w)
+		return
 	}
+	if proj.Slug == "" {
+		proj.Slug = slugify.Slugify(proj.Name)
+	}
+	if proj.Slug == "" {
+		badRequest(w)
+		return
+	}
+	if s.repository.Exists(proj.Slug) {
+		conflict(w)
+		return
+	}
+	proj, err = s.repository.SaveProject(proj.Slug, proj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, proj, http.StatusCreated)
+
 }
 
-func updateProject(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		slug := r.PathValue("slug")
-		proj, err := extractProject(r)
-		if err != nil {
-			badRequest(w)
-			return
-		}
-		if !repository.Exists(slug) {
-			notFound(w)
-			return
-		}
-		proj, err = repository.SaveProject(slug, proj)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		jsonResponse(w, proj, http.StatusAccepted)
+func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	proj, err := extractProject(r)
+	if err != nil {
+		badRequest(w)
+		return
 	}
+	if !s.repository.Exists(slug) {
+		notFound(w)
+		return
+	}
+	proj, err = s.repository.SaveProject(slug, proj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, proj, http.StatusAccepted)
+
 }
 
-func deleteProject(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		slug := r.PathValue("slug")
-		if !repository.Exists(slug) {
-			notFound(w)
-			return
-		}
-		err := repository.DeleteProject(slug)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		emptyResponse(w, http.StatusAccepted)
+func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if !s.repository.Exists(slug) {
+		notFound(w)
+		return
 	}
+	err := s.repository.DeleteProject(slug)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	emptyResponse(w, http.StatusAccepted)
 }
 
-func saveProjectImage(repository project.Repository) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		slug := r.PathValue("slug")
-		if !repository.Exists(slug) {
-			notFound(w)
-			return
-		}
-		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			badRequest(w)
-			return
-		}
-		contentType := r.Header.Get("Content-Type")
-		proj, err := repository.SaveImage(slug, contentType, data)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		jsonResponse(w, proj, http.StatusAccepted)
+func (s *server) saveProjectImage(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if !s.repository.Exists(slug) {
+		notFound(w)
+		return
 	}
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		badRequest(w)
+		return
+	}
+	contentType := r.Header.Get("Content-Type")
+	proj, err := s.repository.SaveImage(slug, contentType, data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, proj, http.StatusAccepted)
+	
 }
 
 func extractProject(req *http.Request) (project.Project, error) {

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -16,8 +16,8 @@ func (s *server) listProjects(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonResponse(w, projects, http.StatusOK)
 
+	jsonResponse(w, projects, http.StatusOK)
 }
 
 func (s *server) loadProject(w http.ResponseWriter, r *http.Request) {
@@ -26,13 +26,14 @@ func (s *server) loadProject(w http.ResponseWriter, r *http.Request) {
 		notFound(w)
 		return
 	}
+
 	proj, err := s.repository.LoadProject(slug)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonResponse(w, proj, http.StatusOK)
 
+	jsonResponse(w, proj, http.StatusOK)
 }
 
 func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
@@ -41,6 +42,7 @@ func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
 		badRequest(w)
 		return
 	}
+
 	if proj.Slug == "" {
 		proj.Slug = slugify.Slugify(proj.Name)
 	}
@@ -52,13 +54,14 @@ func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
 		conflict(w)
 		return
 	}
+
 	proj, err = s.repository.SaveProject(proj.Slug, proj)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonResponse(w, proj, http.StatusCreated)
 
+	jsonResponse(w, proj, http.StatusCreated)
 }
 
 func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
@@ -72,13 +75,14 @@ func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
 		notFound(w)
 		return
 	}
+
 	proj, err = s.repository.SaveProject(slug, proj)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonResponse(w, proj, http.StatusAccepted)
 
+	jsonResponse(w, proj, http.StatusAccepted)
 }
 
 func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
@@ -87,11 +91,12 @@ func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
 		notFound(w)
 		return
 	}
-	err := s.repository.DeleteProject(slug)
-	if err != nil {
+
+	if err := s.repository.DeleteProject(slug); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	emptyResponse(w, http.StatusAccepted)
 }
 
@@ -106,26 +111,29 @@ func (s *server) saveProjectImage(w http.ResponseWriter, r *http.Request) {
 		badRequest(w)
 		return
 	}
+
 	contentType := r.Header.Get("Content-Type")
 	proj, err := s.repository.SaveImage(slug, contentType, data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	jsonResponse(w, proj, http.StatusAccepted)
-	
 }
 
 func extractProject(req *http.Request) (project.Project, error) {
 	var proj project.Project
+
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return proj, err
 	}
-	err = json.Unmarshal(body, &proj)
-	if err != nil {
+
+	if err := json.Unmarshal(body, &proj); err != nil {
 		return proj, err
 	}
+
 	return proj, nil
 }
 

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -22,7 +22,10 @@ func (s *server) listProjects(w http.ResponseWriter, r *http.Request) {
 
 func (s *server) loadProject(w http.ResponseWriter, r *http.Request) {
 	slug := r.PathValue("slug")
-	if !s.repository.Exists(slug) {
+	if exists, err := s.repository.Exists(slug); err != nil {
+		internalServerError(w, err)
+		return
+	} else if !exists {
 		notFound(w)
 		return
 	}
@@ -50,7 +53,10 @@ func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
 		badRequest(w)
 		return
 	}
-	if s.repository.Exists(proj.Slug) {
+	if exists, err := s.repository.Exists(proj.Slug); err != nil {
+		internalServerError(w, err)
+		return
+	} else if exists {
 		conflict(w)
 		return
 	}
@@ -71,7 +77,10 @@ func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
 		badRequest(w)
 		return
 	}
-	if !s.repository.Exists(slug) {
+	if exists, err := s.repository.Exists(slug); err != nil {
+		internalServerError(w, err)
+		return
+	} else if !exists {
 		notFound(w)
 		return
 	}
@@ -87,7 +96,10 @@ func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
 
 func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
 	slug := r.PathValue("slug")
-	if !s.repository.Exists(slug) {
+	if exists, err := s.repository.Exists(slug); err != nil {
+		internalServerError(w, err)
+		return
+	} else if !exists {
 		notFound(w)
 		return
 	}
@@ -102,10 +114,14 @@ func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
 
 func (s *server) saveProjectImage(w http.ResponseWriter, r *http.Request) {
 	slug := r.PathValue("slug")
-	if !s.repository.Exists(slug) {
+	if exists, err := s.repository.Exists(slug); err != nil {
+		internalServerError(w, err)
+		return
+	} else if !exists {
 		notFound(w)
 		return
 	}
+
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		badRequest(w)

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/mozillazg/go-slugify"
 
 	"synyx.de/tales/pkg/project"
@@ -24,8 +23,7 @@ func listProjects(repository project.Repository) http.HandlerFunc {
 
 func loadProject(repository project.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		slug := vars["slug"]
+		slug := r.PathValue("slug")
 		if !repository.Exists(slug) {
 			notFound(w)
 			return
@@ -68,8 +66,7 @@ func createProject(repository project.Repository) http.HandlerFunc {
 
 func updateProject(repository project.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		slug := vars["slug"]
+		slug := r.PathValue("slug")
 		proj, err := extractProject(r)
 		if err != nil {
 			badRequest(w)
@@ -90,8 +87,7 @@ func updateProject(repository project.Repository) http.HandlerFunc {
 
 func deleteProject(repository project.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		slug := vars["slug"]
+		slug := r.PathValue("slug")
 		if !repository.Exists(slug) {
 			notFound(w)
 			return
@@ -107,8 +103,7 @@ func deleteProject(repository project.Repository) http.HandlerFunc {
 
 func saveProjectImage(repository project.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		slug := vars["slug"]
+		slug := r.PathValue("slug")
 		if !repository.Exists(slug) {
 			notFound(w)
 			return

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -13,7 +13,7 @@ import (
 func (s *server) listProjects(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.repository.LoadProjects()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -29,7 +29,7 @@ func (s *server) loadProject(w http.ResponseWriter, r *http.Request) {
 
 	proj, err := s.repository.LoadProject(slug)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -57,7 +57,7 @@ func (s *server) createProject(w http.ResponseWriter, r *http.Request) {
 
 	proj, err = s.repository.SaveProject(proj.Slug, proj)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -78,7 +78,7 @@ func (s *server) updateProject(w http.ResponseWriter, r *http.Request) {
 
 	proj, err = s.repository.SaveProject(slug, proj)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ func (s *server) deleteProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.repository.DeleteProject(slug); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (s *server) saveProjectImage(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 	proj, err := s.repository.SaveImage(slug, contentType, data)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 
@@ -137,6 +137,10 @@ func extractProject(req *http.Request) (project.Project, error) {
 	return proj, nil
 }
 
+func internalServerError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
 func badRequest(w http.ResponseWriter) {
 	http.Error(w, "invalid project", http.StatusBadRequest)
 }
@@ -156,7 +160,7 @@ func emptyResponse(w http.ResponseWriter, code int) {
 func jsonResponse(w http.ResponseWriter, data interface{}, code int) {
 	result, err := json.Marshal(data)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		internalServerError(w, err)
 		return
 	}
 

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -106,7 +106,7 @@ func TestAPI_createProject(t *testing.T) {
 
 		resp := tc.Request("POST", "/api/tales/", project.Project{Slug: "foo"})
 
-		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
+		AssertError(t, resp, tc.dir+" not accessible", 500)
 	})
 }
 
@@ -136,7 +136,7 @@ func TestAPI_loadProject(t *testing.T) {
 
 		resp := tc.Request("GET", "/api/tales/foo", nil)
 
-		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
+		AssertError(t, resp, tc.dir+" not accessible", 500)
 	})
 }
 
@@ -158,7 +158,7 @@ func TestAPI_updateProject(t *testing.T) {
 
 		resp := tc.Request("PUT", "/api/tales/foo", nil)
 
-		AssertError(t, resp, "invalid project\n", 400)
+		AssertError(t, resp, "invalid project", 400)
 	})
 	t.Run("unknown project", func(t *testing.T) {
 		tc := NewTestClient(t)
@@ -175,7 +175,7 @@ func TestAPI_updateProject(t *testing.T) {
 
 		resp := tc.Request("PUT", "/api/tales/foo", project.Project{Slug: "foo"})
 
-		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
+		AssertError(t, resp, tc.dir+" not accessible", 500)
 	})
 }
 
@@ -199,7 +199,7 @@ func TestAPI_deleteProject(t *testing.T) {
 
 		resp := tc.Request("DELETE", "/api/tales/foo", nil)
 
-		AssertError(t, resp, "project not found\n", 404)
+		AssertError(t, resp, "project not found", 404)
 	})
 	t.Run("internal error", func(t *testing.T) {
 		tc := NewTestClient(t)
@@ -207,7 +207,7 @@ func TestAPI_deleteProject(t *testing.T) {
 
 		resp := tc.Request("DELETE", "/api/tales/foo", nil)
 
-		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
+		AssertError(t, resp, tc.dir+" not accessible", 500)
 	})
 }
 
@@ -234,7 +234,7 @@ func TestAPI_updateProjectImage(t *testing.T) {
 
 		resp := tc.Request("PUT", "/api/tales/foo/image", nil)
 
-		AssertError(t, resp, "unsupported content-type: \n", 500)
+		AssertError(t, resp, "unsupported content-type", 500)
 	})
 	t.Run("unknown project", func(t *testing.T) {
 		tc := NewTestClient(t)
@@ -242,7 +242,7 @@ func TestAPI_updateProjectImage(t *testing.T) {
 
 		resp := tc.Request("PUT", "/api/tales/foo/image", nil)
 
-		AssertError(t, resp, "project not found\n", 404)
+		AssertError(t, resp, "project not found", 404)
 	})
 }
 
@@ -259,7 +259,7 @@ func AssertProjectResponse(t *testing.T, resp *http.Response, expected project.P
 func AssertError(t *testing.T, resp *http.Response, errorMsg string, statusCode int) {
 	AssertHTTPError(t, resp, statusCode)
 	body, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, errorMsg, string(body))
+	assert.Contains(t, string(body), errorMsg)
 }
 
 func AssertHTTPError(t *testing.T, resp *http.Response, statusCode int) {

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -30,9 +30,9 @@ func TestAPI_listProjects(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("test-1", project.Project{})
-		tc.repo.SaveProject("test-2", project.Project{})
-		tc.repo.SaveProject("test-3", project.Project{})
+		_, _ = tc.repo.SaveProject("test-1", project.Project{})
+		_, _ = tc.repo.SaveProject("test-2", project.Project{})
+		_, _ = tc.repo.SaveProject("test-3", project.Project{})
 
 		resp := tc.Request("GET", "/api/tales/", nil)
 
@@ -77,7 +77,7 @@ func TestAPI_createProject(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
+		_, _ = tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
 
 		p := project.Project{Slug: "foo", Name: "Bar"}
 		resp := tc.Request("POST", "/api/tales/", p)
@@ -101,14 +101,12 @@ func TestAPI_createProject(t *testing.T) {
 		AssertError(t, resp, "invalid project\n", 400)
 	})
 	t.Run("internal error", func(t *testing.T) {
-		/*
-			tc := NewTestClient(t)
-			tc.Cleanup()
+		tc := NewTestClient(t)
+		tc.Cleanup()
 
-			resp := tc.Request("POST", "/api/tales/", project.Project{Slug: "foo"})
+		resp := tc.Request("POST", "/api/tales/", project.Project{Slug: "foo"})
 
-			AssertError(t, resp, "open "+tc.dir+": no such file or directory\n", 500)
-		*/
+		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
 	})
 }
 
@@ -118,7 +116,7 @@ func TestAPI_loadProject(t *testing.T) {
 		defer tc.Cleanup()
 
 		p := project.Project{Slug: "foo"}
-		tc.repo.SaveProject("foo", p)
+		_, _ = tc.repo.SaveProject("foo", p)
 
 		resp := tc.Request("GET", "/api/tales/foo", nil)
 
@@ -133,14 +131,12 @@ func TestAPI_loadProject(t *testing.T) {
 		AssertError(t, resp, "project not found\n", 404)
 	})
 	t.Run("internal error", func(t *testing.T) {
-		/*
-			tc := NewTestClient(t)
-			tc.Cleanup()
+		tc := NewTestClient(t)
+		tc.Cleanup()
 
-			resp := tc.Request("GET", "/api/tales/foo", nil)
+		resp := tc.Request("GET", "/api/tales/foo", nil)
 
-			AssertError(t, resp, "open "+tc.dir+": no such file or directory\n", 500)
-		*/
+		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
 	})
 }
 
@@ -149,7 +145,7 @@ func TestAPI_updateProject(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
+		_, _ = tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
 
 		p := project.Project{Slug: "foo", Name: "Baz"}
 		resp := tc.Request("PUT", "/api/tales/foo", p)
@@ -174,14 +170,12 @@ func TestAPI_updateProject(t *testing.T) {
 		AssertError(t, resp, "project not found\n", 404)
 	})
 	t.Run("internal error", func(t *testing.T) {
-		/*
-			tc := NewTestClient(t)
-			tc.Cleanup()
+		tc := NewTestClient(t)
+		tc.Cleanup()
 
-			resp := tc.Request("PUT", "/api/tales/", project.Project{Slug: "foo"})
+		resp := tc.Request("PUT", "/api/tales/foo", project.Project{Slug: "foo"})
 
-			AssertError(t, resp, "open "+tc.dir+": no such file or directory\n", 500)
-		*/
+		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
 	})
 }
 
@@ -190,7 +184,7 @@ func TestAPI_deleteProject(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("foo", project.Project{Slug: "foo"})
+		_, _ = tc.repo.SaveProject("foo", project.Project{Slug: "foo"})
 
 		resp := tc.Request("DELETE", "/api/tales/foo", nil)
 
@@ -208,14 +202,12 @@ func TestAPI_deleteProject(t *testing.T) {
 		AssertError(t, resp, "project not found\n", 404)
 	})
 	t.Run("internal error", func(t *testing.T) {
-		/*
-			tc := NewTestClient(t)
-			tc.Cleanup()
+		tc := NewTestClient(t)
+		tc.Cleanup()
 
-			resp := tc.Request("DELETE", "/api/tales/foo", nil)
+		resp := tc.Request("DELETE", "/api/tales/foo", nil)
 
-			AssertError(t, resp, "open "+tc.dir+": no such file or directory\n", 500)
-		*/
+		AssertError(t, resp, "stat "+tc.dir+": no such file or directory\n", 500)
 	})
 }
 
@@ -224,7 +216,7 @@ func TestAPI_updateProjectImage(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
+		_, _ = tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
 
 		data := []byte{'f', 'o', 'o'}
 		header := http.Header(map[string][]string{})
@@ -238,7 +230,7 @@ func TestAPI_updateProjectImage(t *testing.T) {
 		tc := NewTestClient(t)
 		defer tc.Cleanup()
 
-		tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
+		_, _ = tc.repo.SaveProject("foo", project.Project{Slug: "foo", Name: "Bar"})
 
 		resp := tc.Request("PUT", "/api/tales/foo/image", nil)
 


### PR DESCRIPTION
* Remove external `gorilla` dependency, no longer needed as go 1.22 includes support for http verbs
* Finish implementation of returning internal server errors in API server