### PR TITLE
Combine dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      node:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -15,6 +21,12 @@ updates:
     labels:
       - "dependencies"
       - "go"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      go:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,3 +35,9 @@ updates:
     labels:
       - "dependencies"
       - "github_actions"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
* To simplify maintenance, group all PRs, this should lessen the maintenance load.
* I recently updated just about every dependency in #374, there were no real problems.  However, it could be that single dependencies introduce regressions.  When that happens, the tests should catch that.